### PR TITLE
Cleans up module syntax for consistency

### DIFF
--- a/routes/parseWildCardRoute.js
+++ b/routes/parseWildCardRoute.js
@@ -1,6 +1,6 @@
 'use strict';
 
-module.exports = (pathname, routesJson) => {
+const parseWildCardRoutes = (pathname, routesJson) => {
 
         var matchedRoute = Object.keys(routesJson).find(function (route) {
                 return !!(pathname.match(routesJson[route].regex));
@@ -16,3 +16,5 @@ module.exports = (pathname, routesJson) => {
 
         return {route: routeInfo, values: values};
     };
+
+module.exports = parseWildCardRoutes;


### PR DESCRIPTION
These were the only modules not declaring their export as a
variable at the top of the page. I like that syntax... so sticking
to it.

The only exception to the rule is the tools module. All of the
functions in it so far are crazy simple and fit in the export
statement nicely. So that is how it will stay for now.