### PR TITLE
Updates dependencies, simplifies parsing, and adds tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,22 +38,21 @@
   "dependencies": {
     "dot": "^1.0.3",
     "etag": "^1.7.0",
-    "event-state": "^0.3.5",
-    "glob": "^5.0.14",
-    "harken": "^1.0.2",
+    "glob": "^5.0.15",
+    "harken": "^1.0.4",
     "media-typer": "^0.3.0",
     "mime": "^1.3.4",
-    "raw-body": "^2.1.3"
+    "raw-body": "^2.1.4"
   },
   "devDependencies": {
-    "chai": "^3.2.0",
+    "chai": "^3.3.0",
     "chalk": "^1.1.1",
     "gulp": "^3.9.0",
     "gulp-coveralls": "^0.1.4",
-    "gulp-istanbul": "^0.10.0",
+    "gulp-istanbul": "^0.10.1",
     "gulp-mocha": "^2.1.3",
     "minimist": "^1.2.0",
-    "v8-profiler": "^5.3.1"
+    "v8-profiler": "^5.3.2"
   },
   "engines": {
     "node": "^4.0.0"

--- a/utils/parseForm.js
+++ b/utils/parseForm.js
@@ -1,0 +1,19 @@
+'use strict';
+
+const parseForm = (formString) => {
+        const keys  = formString.match(/(name=")([^"]+)(")([^a-zA-Z0-9]+)([^-]+)/g);
+
+        if (keys !== null) {
+            return keys.reduce((prev, current) => {
+                const temp = current.match(/(")([^"])+/);
+
+                prev[temp[0].replace(/"/g, '')] = current.match(/([\s].+)/)[0].replace(/^[\s]/, '');
+
+                return prev;
+            }, {});
+        } else {
+            return {};
+        }
+    };
+
+module.exports = parseForm;

--- a/utils/parseForm_test.js
+++ b/utils/parseForm_test.js
@@ -1,0 +1,22 @@
+'use strict';
+
+const assert = require('chai').assert
+    , parseForm = require('./parseForm')
+    , validString = '------WebKitFormBoundary13WN3NA3Cv1LBWIx\nContent-Disposition: form-data; name="name"\n\ndaniel\n------WebKitFormBoundary13WN3NA3Cv1LBWIx\nContent-Disposition: form-data; name="title"\n\nlord of the interwebz\n------WebKitFormBoundary13WN3NA3Cv1LBWIx--\n';
+
+describe('parseForm Tests', () => {
+  it('should return a function ', () => {
+    assert.isFunction(parseForm);
+  });
+
+  it('should parse a form string out correctly', () => {
+    assert.isObject(parseForm(validString));
+    assert.strictEqual(parseForm(validString).name, 'daniel');
+    assert.strictEqual(parseForm(validString).title, 'lord of the interwebz');
+  });
+
+  it('should return an empty object if no form string', () => {
+    assert.isObject(parseForm('this is bogus'));
+    assert.strictEqual(Object.keys(parseForm('this is something')).length, 0);
+  });
+});

--- a/utils/parser.js
+++ b/utils/parser.js
@@ -5,22 +5,7 @@ const getRawBody = require('raw-body')
     , querystring = require('querystring')
     , events = require('harken')
     , tools = require('./tools')
-
-    , parseForm = (formString) => {
-        const keys  = formString.match(/(name=")([^"]+)(")([^a-zA-Z0-9]+)([^-]+)/g);
-
-        if (keys !== null) {
-            return keys.reduce((prev, current) => {
-                const temp = current.match(/(")([^"])+/);
-
-                prev[temp[0].replace(/"/g, '')] = current.match(/([\s].+)/)[0].replace(/^[\s]/, '');
-
-                return prev;
-            }, {});
-        } else {
-            return {};
-        }
-    }
+    , parseForm = require('./parseForm')
 
     , parser = (connection, callback, scope) => {//parse out the body
         let encoding = 'UTF-8';


### PR DESCRIPTION
First off this commit removes the explicit dependency on
event-state. This module was used back in the ancient days
when we were not using harken. But since harken includes it
already and provides a .required of its own we don't need
event-state any more.

Second, this commit breaks out the form string parsing into its
own module. This allows it to be tested directly, and updated
directly. Simplifies the parser.js file a bit and makes things
a little more tidy.

Lastly, adds tests for the parseForm module. This was what spurred
the change above. Because it had the last line of code in parser.js
that was not tested. Pulling it out and testing it means that both
of them are now 100% covered by unit tests.

One weird side note... I am seeing some inconsistent test failures
in the static routing stuff. Not sure why and will investigate
further in the future.