### PR TITLE
Adds support for the x-powered-by header

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -8,6 +8,14 @@
 
 [![Coverage Status](https://coveralls.io/repos/ansble/monument/badge.svg?branch=master)](https://coveralls.io/r/ansble/monument?branch=master)
 
+## v2.1.0
+
+Config changes:
+
+#### poweeredBy
+You can set this value to whatever you want it to look like your server is powered by. By default it is off and the server does not return the `X-Powered-By` header. This is more secure then specifying it so we receommend you leave this alone, but since you are an adult you are free to set a value here. Any string passed here will become the value of the `X-Powered-By` header.
+
+
 ## v2.0.0!
 Despite it being a major release this is actually a pretty bland one. It's a major release because monument 2+ requires you to be running on node > 4.0.0. It is a rewrite and cleanup in ES6 syntax.
 

--- a/routes/router.js
+++ b/routes/router.js
@@ -40,6 +40,10 @@ module.exports = (routesJson, config) => {
             //add .send to the response
             res.send = utils.send(req, config);
 
+            if (utils.isDefined(config.security) && utils.isDefined(config.security.poweredBy)) {
+                res.setHeader('X-Powered-By', config.security.poweredBy);
+            }
+
             //match the first part of the url... for public stuff
             if (publicFolders.indexOf(pathname.split('/')[1]) !== -1) {
                 //static assets y'all


### PR DESCRIPTION
By default this header is not sent and that continues to be the
case. But if you want to send it you now may. It lives in the
security section of the config object. DO NOT use this unless you
are trying to be funny and/or understand the security ramifications.

The default is secure. Changing from it is less so.

fixes #115 