### PR TITLE
Adds support for the X-Content-Type-Options header

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -11,7 +11,7 @@
 ## v2.1.0
 
 ###Config changes:
-Current state of the config object is right below this. Explanations about the new items in the security object are explained in more depth below.
+Current state of the config object is right below this. Explanations about the new items in the security object are explained in more depth below. Most of the settings in security turn headers on and off, and documentation around those headers can be found on [OWASP](https://www.owasp.org/index.php/List_of_useful_HTTP_headers) and n [helmet and its source code](https://www.npmjs.com/package/helmet). Much of the code here is inspired by helmet.
 
 ```
 {
@@ -31,6 +31,7 @@ Current state of the config object is right below this. Explanations about the n
     , security: {
         xssProtection: true //default, can be set to false to disable
         , poweredBy: 'bacon' //the default is blank can be any string
+        , noSniff: true //default, can be set to false to disable
     }
 }
 ```
@@ -40,6 +41,9 @@ You can set this value to whatever you want it to look like your server is power
 
 #### xssProtection
 If set to false this turns off the X-XSS-Protection header for all browsers. This header is disabled in IE < 9 because it opens up vulnerabilities. In everything else it is enabled by default.
+
+#### noSniff
+If set to false this turns off the X-Content-Type-Options header for all browsers. This header prevents browsers from trying to infer mime type when a file with a mime type is downloaded. This helps prevent download related vulnerabilities and the misinterpretation of file types.
 
 ## v2.0.0!
 Despite it being a major release this is actually a pretty bland one. It's a major release because monument 2+ requires you to be running on node > 4.0.0. It is a rewrite and cleanup in ES6 syntax.

--- a/security/index.js
+++ b/security/index.js
@@ -1,7 +1,8 @@
 'use strict';
 
 const poweredBy = require('./poweredByHeader')
-    , xssHeader = require('./xssHeader');
+    , xssHeader = require('./xssHeader')
+    , noSniff = require('./noSniff');
 
 module.exports = (config, reqIn, resIn) => {
     let res = resIn
@@ -9,6 +10,7 @@ module.exports = (config, reqIn, resIn) => {
 
     res = poweredBy(config, res);
     res = xssHeader(config, res, req);
+    res = noSniff(config, res);
 
     return res;
 };

--- a/security/noSniff.js
+++ b/security/noSniff.js
@@ -1,0 +1,13 @@
+'use strict';
+
+const isDefined = require('../utils').isDefined;
+
+
+module.exports = (config, res) => {
+    if (isDefined(config.security) && isDefined(config.security.noSniff) && config.security.noSniff === false) {
+        return res;
+    } else {
+        res.setHeader('X-Content-Type-Options', 'nosniff');
+        return res;
+    }
+};

--- a/security/noSniff_test.js
+++ b/security/noSniff_test.js
@@ -1,0 +1,46 @@
+'use strict';
+
+const assert = require('chai').assert
+    , noSniff = require('./noSniff');
+
+let res = {}
+  , config = {};
+
+describe('Security Headers: X-Content-Type-Options Tests', () => {
+  beforeEach(() => {
+    res.headers = {};
+    res.setHeader = function (key, value) {
+      this.headers[key] = value;
+    };
+
+    config.security = {};
+  });
+
+  it('should return a function', () => {
+    assert.isFunction(noSniff);
+  });
+
+  it('should set a header if there is no option in config', () => {
+    noSniff(config, res);
+
+    assert.strictEqual(res.headers['X-Content-Type-Options'], 'nosniff');
+  });
+
+  it('should set a header if the config is true', () => {
+    config.security.noSniff = true;
+    noSniff(config, res);
+
+    assert.strictEqual(res.headers['X-Content-Type-Options'], 'nosniff');
+  });
+
+  it('should not set a header if the config is false', () => {
+    config.security.noSniff = false;
+    noSniff(config, res);
+
+    assert.isUndefined(res.headers['X-Content-Type-Options']);
+  });
+
+  it('should return res when executed', () => {
+    assert.strictEqual(res, noSniff(config, res));
+  });
+});


### PR DESCRIPTION
This adds support for the nosniff header and documentation
and tests around it.

closes #119