### PR TITLE
Adds a redirect function to the response object

### DIFF
--- a/routes/router.js
+++ b/routes/router.js
@@ -39,6 +39,7 @@ module.exports = (routesJson, config) => {
 
             //add .send to the response
             res.send = utils.send(req, config);
+            res.redirect = utils.redirect(req);
 
             //match the first part of the url... for public stuff
             if (publicFolders.indexOf(pathname.split('/')[1]) !== -1) {

--- a/utils/index.js
+++ b/utils/index.js
@@ -2,6 +2,7 @@
 
 const getCompression = require('./getCompression')
     , send = require('./send')
+    , redirect = require('./redirect')
     , setup = require('./setup')
     , parsePath = require('./url')
     , events = require('harken')
@@ -10,6 +11,7 @@ const getCompression = require('./getCompression')
 module.exports = {
     getCompression: getCompression
     , send: send
+    , redirect: redirect
     , parsePath: parsePath
     , isDefined: tools.isDefined
     , not: tools.not

--- a/utils/index_test.js
+++ b/utils/index_test.js
@@ -13,29 +13,36 @@ describe('Utils Tests', () => {
     assert.isFunction(utils.parsePath);
     assert.isFunction(utils.isDefined);
     assert.isFunction(utils.not);
+    assert.isFunction(utils.redirect);
   });
 
   describe('getCompression tests', () => {
     it('should return deflate if the deflate header is passed in', () => {
       assert.strictEqual(utils.getCompression('deflate', {compress: true}), 'deflate');
     });
+
     it('should return gzip if gzip is in the header passed in', () => {
       assert.strictEqual(utils.getCompression('gzip', {compress: true}), 'gzip');
     });
+
     it('should return gzip if both gzip and deflate are in the header', () => {
       assert.strictEqual(utils.getCompression('deflate gzip', {compress: true}), 'gzip');
     });
+
     it('should return none if no header is passed in', () => {
       let header; //has no value... just exists
 
       assert.strictEqual(utils.getCompression(header, {compress: true}), 'none');
     });
+
     it('should return none if an empty header is passed in', () => {
       assert.strictEqual(utils.getCompression('', {compress: true}), 'none');
     });
+
     it('should return none if compression is turned off no matter what the header is', () => {
       assert.strictEqual(utils.getCompression('gzip', {compress: false}), 'none');
     });
+
     it('should return correct compression if compression is not in the config', () => {
       assert.strictEqual(utils.getCompression('gzip', {}), 'gzip');
     });

--- a/utils/redirect.js
+++ b/utils/redirect.js
@@ -1,0 +1,24 @@
+'use strict';
+
+const statusCodes = require('http').STATUS_CODES
+    , events = require('harken')
+    , redirect = (req) => {
+        return function (url, status) {
+            if(typeof url === 'undefined') {
+                events.emit('error:500', 'you must pass an URL to the redirect method');
+                return;
+            }
+
+            this.setHeader('location', url);
+            this.statusCode = status || 307;
+
+            if(req.method === 'HEAD') {
+                this.end();
+            } else {
+                this.end(this.statusCode + ' ' + statusCodes[this.statusCode] + ' to ' + encodeURI(url));
+            }
+        };
+    };
+
+
+module.exports = redirect;

--- a/utils/redirect_test.js
+++ b/utils/redirect_test.js
@@ -1,0 +1,101 @@
+'use strict';
+
+const assert = require('chai').assert
+    , redirect = require('./redirect')
+    , events = require('harken');
+
+let fakeRes
+    , fakeOut
+    , fakeEncode
+    , fakeHeaders
+    , fakeHead;
+
+describe('Redirect Tests', () => {
+    beforeEach(() => {
+        fakeHeaders = {};
+
+        fakeRes = {
+            setHeader: (key, value) => {
+                fakeHeaders[key] = value;
+            }
+            , end: (data, encode) => {
+                fakeOut = data;
+                fakeEncode = encode;
+            },
+            statusCode: 200
+        };
+
+        fakeHead = {
+            setHeader: (key, value) => {
+                fakeHeaders[key] = value;
+            }
+            , end: (data, encode) => {
+                fakeOut = data;
+                fakeEncode = encode;
+            },
+            statusCode: 200
+        };
+
+        fakeRes.redirect = redirect({
+            headers: {
+                'accept-encoding': 'none'
+                , 'if-none-match': ''
+            }
+        });
+
+        fakeHead.redirect = redirect({
+            headers: {
+                'accept-encoding': 'none'
+                , 'if-none-match': ''
+            }
+            , method: 'HEAD'
+        });
+
+        fakeOut = '';
+    });
+
+    it('should be defined as a function', () => {
+        assert.isFunction(redirect);
+    });
+
+    it('should return a function', () => {
+        assert.isFunction(redirect({}));
+    });
+
+    it('should raise a 500 error event if no url is passed', (done) => {
+        events.once('error:500', (msg) => {
+            assert.isDefined(msg);
+            done();
+        });
+
+        fakeRes.redirect();
+    });
+
+    it('should default to 307 for just an url passed', () => {
+        fakeRes.redirect('www.google.com');
+        assert.strictEqual(fakeOut, '307 Temporary Redirect to www.google.com');
+        assert.strictEqual(fakeHeaders.location, 'www.google.com');
+        assert.strictEqual(fakeRes.statusCode, 307);
+    });
+
+    it('should allow a statusCode to be passed in', () => {
+        fakeRes.redirect('www.google.com', 302);
+        assert.strictEqual(fakeOut, '302 Found to www.google.com');
+        assert.strictEqual(fakeHeaders.location, 'www.google.com');
+        assert.strictEqual(fakeRes.statusCode, 302);
+    });
+
+    it('should return an empty body if \'HEAD\' request and specified type', () => {
+        fakeHead.redirect('www.google.com', 302);
+        assert.strictEqual(fakeOut, undefined);
+        assert.strictEqual(fakeHeaders.location, 'www.google.com');
+        assert.strictEqual(fakeHead.statusCode, 302);
+    });
+
+    it('should return an empty body if \'HEAD\' request and no type', () => {
+        fakeHead.redirect('www.google.com');
+        assert.strictEqual(fakeOut, undefined);
+        assert.strictEqual(fakeHeaders.location, 'www.google.com');
+        assert.strictEqual(fakeHead.statusCode, 307);
+    });
+});


### PR DESCRIPTION
Express has a handy redirect that handles sending redirects
for you. Now monument does too. Added as a result of me needing
one for designfrontier.net

Fixes #134 