### PR TITLE
Improves performance of CSP header and improves quality of tests

### DIFF
--- a/routes/router_test.js
+++ b/routes/router_test.js
@@ -65,7 +65,9 @@ describe('Route Handler Tests', () => {
                 done();
             });
 
-            routeHandler(req, res);
+            process.nextTick(() => {
+                routeHandler(req, res);
+            });
         });
     });
 
@@ -93,7 +95,9 @@ describe('Route Handler Tests', () => {
                 done();
             });
 
-            routeHandler(req, res);
+            process.nextTick(() => {
+                routeHandler(req, res);
+            });
         });
     });
 
@@ -106,7 +110,9 @@ describe('Route Handler Tests', () => {
                 done();
             });
 
-            routeHandler(req, res);
+            process.nextTick(() => {
+                routeHandler(req, res);
+            });
         });
 
         it('should pass variables on the connection.params from the url', (done) => {
@@ -119,7 +125,9 @@ describe('Route Handler Tests', () => {
                 done();
             });
 
-            routeHandler(req, res);
+            process.nextTick(() => {
+                routeHandler(req, res);
+            });
         });
     });
 
@@ -132,7 +140,9 @@ describe('Route Handler Tests', () => {
                 done();
             });
 
-            routeHandler(req, res);
+            process.nextTick(() => {
+                routeHandler(req, res);
+            });
         });
     });
 
@@ -152,7 +162,9 @@ describe('Route Handler Tests', () => {
                 done();
             });
 
-            routeHandler(req, res);
+            process.nextTick(() => {
+                routeHandler(req, res);
+            });
         });
 
         it('should emit 404 event for a non-existant static file in the root of public', (done) => {
@@ -163,7 +175,9 @@ describe('Route Handler Tests', () => {
                 done();
             });
 
-            routeHandler(req, res);
+            process.nextTick(() => {
+                routeHandler(req, res);
+            });
         });
 
         it('should return the file for an existing static file with no etag', (done) => {
@@ -175,7 +189,9 @@ describe('Route Handler Tests', () => {
                 done();
             });
 
-            routeHandler(req, res);
+            process.nextTick(() => {
+                routeHandler(req, res);
+            });
         });
 
         it('should return a 304 for a valid etag match', (done) => {
@@ -189,7 +205,9 @@ describe('Route Handler Tests', () => {
                 done();
             });
 
-            routeHandler(req, res);
+            process.nextTick(() => {
+                routeHandler(req, res);
+            });
         });
 
         it('should return just headers if a head request is sent', (done) => {
@@ -205,7 +223,9 @@ describe('Route Handler Tests', () => {
                 done();
             });
 
-            routeHandler(req, res);
+            process.nextTick(() => {
+                routeHandler(req, res);
+            });
         });
     });
 
@@ -221,7 +241,9 @@ describe('Route Handler Tests', () => {
                 done();
             });
 
-            routeHandler(req, res);
+            process.nextTick(() => {
+                routeHandler(req, res);
+            });
 
         });
     });

--- a/security/contentSecurityPolicyBrowserHandlers.js
+++ b/security/contentSecurityPolicyBrowserHandlers.js
@@ -44,8 +44,8 @@ handlers.default = function () {
 
 handlers.IE = function (browser) {
     const headerSwitchVersion = 12
-        , xHeader = browser.version < headerSwitchVersion
-        , header = xHeader ? 'X-Content-Security-Policy' : 'Content-Security-Policy';
+        , header = browser.version < headerSwitchVersion ?
+            'X-Content-Security-Policy' : 'Content-Security-Policy';
 
     return { headers: [ header ] };
 };
@@ -54,13 +54,13 @@ handlers.Firefox = function (browser, directives) {
     const version = parseFloat(browser.version)
         , policy = shallowCopy(directives)
 
-        , upperSplitVersion = 23
-        , bottomVersion = 4
-        , defaultSrcThreshold = 5;
+        , TWENTYTHREE = 23
+        , FOUR = 4
+        , FIVE = 5;
 
-    if (version >= upperSplitVersion) {
+    if (version >= TWENTYTHREE) {
         return { headers: [ 'Content-Security-Policy' ] };
-    } else if (version >= bottomVersion && version < upperSplitVersion) {
+    } else if (version >= FOUR && version < TWENTYTHREE) {
         policy.defaultSrc = policy.defaultSrc || [ '*' ];
 
         Object.keys(policy).forEach((key) => {
@@ -69,7 +69,7 @@ handlers.Firefox = function (browser, directives) {
             if (key === 'connectSrc') {
                 policy.xhrSrc = value;
             } else if (key === 'defaultSrc') {
-                if (version < defaultSrcThreshold) {
+                if (version < FIVE) {
                     policy.allow = value;
                 } else {
                     policy.defaultSrc = value;
@@ -94,12 +94,12 @@ handlers.Firefox = function (browser, directives) {
 handlers.Chrome = function (browser) {
     const version = parseFloat(browser.version)
 
-    , upperSplitVersion = 25
-    , lowerSupportedVersion = 14;
+    , TWENTYFIVE = 25
+    , FOURTEEN = 14;
 
-    if (version >= lowerSupportedVersion && version < upperSplitVersion) {
+    if (version >= FOURTEEN && version < TWENTYFIVE) {
         return { headers: [ 'X-WebKit-CSP' ] };
-    } else if (version >= upperSplitVersion) {
+    } else if (version >= TWENTYFIVE) {
         return { headers: [ 'Content-Security-Policy' ] };
     } else {
         return SET_NOTHING;
@@ -108,12 +108,12 @@ handlers.Chrome = function (browser) {
 
 handlers.Safari = function (browser, directives, options) {
     const version = parseFloat(browser.version)
-        , upperSplitVersion = 7
-        , headerSwitchVersion = 6;
+        , SEVEN = 7
+        , SIX = 6;
 
-    if (version >= upperSplitVersion) {
+    if (version >= SEVEN) {
         return { headers: [ 'Content-Security-Policy' ] };
-    } else if (version >= headerSwitchVersion || options.safari5) {
+    } else if (version >= SIX || options.safari5) {
         return { headers: [ 'X-WebKit-CSP' ] };
     } else {
         return SET_NOTHING;
@@ -121,9 +121,9 @@ handlers.Safari = function (browser, directives, options) {
 };
 
 handlers.Opera = function (browser) {
-    const supportThreshold = 15;
+    const FIFTEEN = 15;
 
-    if (parseFloat(browser.version) >= supportThreshold) {
+    if (parseFloat(browser.version) >= FIFTEEN) {
         return { headers: [ 'Content-Security-Policy' ] };
     } else {
         return SET_NOTHING;
@@ -131,9 +131,9 @@ handlers.Opera = function (browser) {
 };
 
 handlers['Android Browser'] = function (browser, directives, options) {
-    const supportThreshold = 4.4;
+    const FOURPOINTFOUR = 4.4;
 
-    if (parseFloat(browser.os.version) < supportThreshold || options.disableAndroid) {
+    if (parseFloat(browser.os.version) < FOURPOINTFOUR || options.disableAndroid) {
         return SET_NOTHING;
     } else {
         return { headers: [ 'Content-Security-Policy' ] };

--- a/security/contentSecurityPolicy_test.js
+++ b/security/contentSecurityPolicy_test.js
@@ -53,10 +53,16 @@ describe('content security policy', () => {
         };
 
         config.security = {};
+
+        csp.flushCache();
     });
 
     it('returns a function', () => {
         assert.isFunction(csp);
+    });
+
+    it('should have a flushCache function', () => {
+        assert.isFunction(csp.flushCache);
     });
 
     it('sets headers by string', () => {


### PR DESCRIPTION
The tests were intermittently failing because of a timing issue.
They are now process.nextTicked to prevent that in the future and
passing 100% of the time.

CSP was generating the header on evry request but there are really
only 3 possible values for a given config. Since config can only be
changed at server startup it makes sense to cache these three values
and return them faster. This implements caching.