### PR TITLE
add version badge to the README.md file

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,7 @@
 
 [![NPM](https://nodei.co/npm/monument.png?downloadRank=true&stars=true)](https://nodei.co/npm/monument/)
 
-[![npm version](https://img.shields.io/npm/v/monument.svg)](https://www.npmjs.com/package/monument)
+[![npm version](https://img.shields.io/npm/v/monument.svg?style=flat-square)](https://www.npmjs.com/package/monument)
 
 ![build status](https://codeship.com/projects/881ed090-9c54-0132-655c-263ab955f60c/status?branch=master) 
 

--- a/readme.md
+++ b/readme.md
@@ -4,6 +4,8 @@
 
 [![NPM](https://nodei.co/npm/monument.png?downloadRank=true&stars=true)](https://nodei.co/npm/monument/)
 
+[![npm version](https://img.shields.io/npm/v/monument.svg)](https://www.npmjs.com/package/monument)
+
 ![build status](https://codeship.com/projects/881ed090-9c54-0132-655c-263ab955f60c/status?branch=master) 
 
 [![David](https://img.shields.io/david/ansble/monument.svg?style=flat-square)](https://david-dm.org/ansble/monument)


### PR DESCRIPTION
Hi! I saw this issue -- https://github.com/ansble/monument/issues/180 -- linked on the up-for-grabs.net site, so I thought I'd make the fix and submit a PR!

This change adds the npm badge to the README.md file with an outbound link to the packages's page on npmjs.com.

Let me know if you'd like this to include any additional changes!