### PR TITLE
Adds the .npmignore file

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,9 @@
+docs/
+coverage/
+test_stubs/
+bin/
+.codeclimate.yml
+.editorconfig
+.eslintrc
+.linthub.yml
+.gitignore


### PR DESCRIPTION
Excludes the following directories:
docs
coverage
test_stubs
bin

and the following dot files:
.gitignore
.codeclimate.yml
.eslintrc
.editorconfig
.linthub.yml

These files are not needed for the module's use and are really
development concerns. So there was no need for them to be loaded
with every install of monument.

This should cut the installed size by about 1.9MB maybe a little
more.