### PR TITLE
Fix URLs in Monument-in-action.md

### DIFF
--- a/docs/Monument-in-action.md
+++ b/docs/Monument-in-action.md
@@ -1,9 +1,9 @@
 # Sites using monument
 
-- [Hack Night SLC](http://ha knightly.com)
-- [designfrontier](http://designfrontier.net)
-- [ansble store](http.ansble.com) a generic REST API data store. Hosted and self-hosted options
-- [door prizes for eventbrite events](prizes.ansble.com)
+- [Hack Night SLC](http://www.hacknightslc.com)
+- [designfrontier](http://www.designfrontier.net)
+- [ansble store](http://www.ansble.com) a generic REST API data store. Hosted and self-hosted options
+- [door prizes for eventbrite events](http://prizes.ansble.com)
 
 ## add yours!
 


### PR DESCRIPTION
Hi, I've fixed the URLs in the Monument-in-action.md
For the "Hack Night SLC", I'm not sure if that's the right URL because the original one looks like "hacknightly.com" but that site does not go to the Hack Night SLC site. Let me know if it's supposed to go there instead. Thanks!