### PR TITLE
Add handleStaticFile unit tests

### DIFF
--- a/routes/handleStaticFile.js
+++ b/routes/handleStaticFile.js
@@ -78,6 +78,7 @@ module.exports = (file, connection, config) => {
           });
 
           res.end();
+          events.emit('static:headed', pathname);
         } else if (not(compression === 'none')) {
           // we have compression!
           res.writeHead(succesStatus, {

--- a/routes/handleStaticFile_test.js
+++ b/routes/handleStaticFile_test.js
@@ -1,0 +1,78 @@
+/* eslint-env node, mocha */
+'use strict';
+
+const assert = require('chai').assert
+      , stream = require('stream')
+      , path = require('path')
+      , events = require('harken')
+      , handleStaticFile = require('./handleStaticFile')
+      , getConnectionMock = (method, pathname) => {
+        const mock = {
+          req: {
+            method: method
+            , headers: {
+              'accept-encoding': '*'
+              , 'if-none-match': '*'
+            }
+          }
+          , res: new stream.Writable()
+          , query: ''
+          , params: {}
+          , path: {
+            pathname: pathname
+          }
+        };
+
+        mock.res.writeHead = () => {};
+        mock.res.setHeader = () => {};
+        return mock;
+      }
+      , withPath = (filePath) => {
+        return path.join(process.cwd(), 'test_stubs/templates', filePath);
+      };
+
+describe('handleStaticFile Tests', () => {
+  beforeEach(() => {
+    events.off('static:served');
+    events.off('static:headed');
+    events.off('static:missing');
+    events.off('error:404');
+  });
+
+  it('should handle a static file', (done) => {
+    const connectionMock = getConnectionMock('GET', 'main.js');
+
+    events.once('static:served', (name) => {
+      assert.equal(name, connectionMock.path.pathname);
+      done();
+    });
+    handleStaticFile(withPath('example.js'), connectionMock, {
+      maxAge: 1000
+      , compress: false
+    });
+  });
+
+  it('should handle the HEAD to a static file', (done) => {
+    const connectionMock = getConnectionMock('HEAD', 'main.js');
+
+    events.once('static:headed', (name) => {
+      assert.equal(name, connectionMock.path.pathname);
+      done();
+    });
+    handleStaticFile(withPath('example.js'), connectionMock, { maxAge: 1000, compress: false });
+  });
+
+  it('should give 404 for static files missing', (done) => {
+    const connectionMock = getConnectionMock('GET', 'nonExistingfile.jpg');
+
+    events.once('static:missing', (name) => {
+      assert.equal(name, connectionMock.path.pathname);
+    });
+    events.once('error:404', (connectionObject) => {
+      assert.equal(connectionObject.req.method, 'GET');
+      assert.equal(connectionObject.path.pathname, 'nonExistingfile.jpg');
+      done();
+    });
+    handleStaticFile('nonExistingfile.jpg', connectionMock, { maxAge: 1000, compress: false });
+  });
+});

--- a/routes/router_test.js
+++ b/routes/router_test.js
@@ -60,6 +60,7 @@ describe('Route Handler Tests', () => {
     /* eslint-enable no-underscore-dangle */
 
     events.off('error:404');
+    events.off('static:served');
     events.off('static:missing');
     events.off('response');
     events.off('route:/about:get');


### PR DESCRIPTION
This PR basically fixes three pitfalls:

- First of all we deeply unit test handleStaticFile.js as per #448 
- We add a `static:headed` event to our event pool, mainly to trace when this kind of response is closed
- We didn't "off" the `static:served` event inside router's `beforeEach`. As a result, I was getting a lot of error when I attempted to assert on that specific payload during my work. I fixed this adding the missing statement inside router's unit tests.