### PR TITLE
removes 300-500 status codes from the default statsd

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3830,15 +3830,44 @@
       "dev": true
     },
     "iltorb": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/iltorb/-/iltorb-2.3.0.tgz",
-      "integrity": "sha512-ETqIIV1CxwALD8UjLTP0aimJuuQ2fBQdYk4neZIMHb6HGQwnZcSu+8NX31F92FY/P4QyuZS++xeUn96qi/XoNQ==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/iltorb/-/iltorb-2.3.2.tgz",
+      "integrity": "sha512-FOmQvlD8kHnCugvGPbn/wSp5qa96hxH85mzfkJ1AEDZznB1CnJCnXlD+j/fW5xlbZfownrOaPtwISufH6oAO1Q==",
       "requires": {
         "detect-libc": "1.0.3",
-        "nan": "2.8.0",
+        "nan": "2.10.0",
         "npmlog": "4.1.2",
-        "prebuild-install": "2.5.1",
+        "prebuild-install": "3.0.0",
         "which-pm-runs": "1.0.0"
+      },
+      "dependencies": {
+        "nan": {
+          "version": "2.10.0",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
+          "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA=="
+        },
+        "prebuild-install": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-3.0.0.tgz",
+          "integrity": "sha512-9kuOu84mRwlQV3JyD+tkYiJtTbeEVtPf0z91OvU89llsT8Y1mjZyz8jyMzMrCj+UynQzzaEc/p31IZBqXG77rA==",
+          "requires": {
+            "detect-libc": "1.0.3",
+            "expand-template": "1.1.0",
+            "github-from-package": "0.0.0",
+            "minimist": "1.2.0",
+            "mkdirp": "0.5.1",
+            "node-abi": "2.3.0",
+            "noop-logger": "0.1.1",
+            "npmlog": "4.1.2",
+            "os-homedir": "1.0.2",
+            "pump": "2.0.1",
+            "rc": "1.2.1",
+            "simple-get": "2.7.0",
+            "tar-fs": "1.16.0",
+            "tunnel-agent": "0.6.0",
+            "which-pm-runs": "1.0.0"
+          }
+        }
       }
     },
     "import-lazy": {
@@ -4833,7 +4862,9 @@
     "nan": {
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.8.0.tgz",
-      "integrity": "sha1-7XFfP+neArV6XmJS2QqWZ14fCFo="
+      "integrity": "sha1-7XFfP+neArV6XmJS2QqWZ14fCFo=",
+      "dev": true,
+      "optional": true
     },
     "natural-compare": {
       "version": "1.4.0",
@@ -7061,6 +7092,7 @@
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-2.5.1.tgz",
       "integrity": "sha512-3DX9L6pzwc1m1ksMkW3Ky2WLgPQUBiySOfXVl3WZyAeJSyJb4wtoH9OmeRGcubAWsMlLiL8BTHbwfm/jPQE9Ag==",
+      "optional": true,
       "requires": {
         "detect-libc": "1.0.3",
         "expand-template": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "glob": "7.1.2",
     "harken": "1.2.18",
     "html-entities": "^1.2.1",
-    "iltorb": "2.3.0",
+    "iltorb": "2.3.2",
     "lodash.clonedeep": "4.5.0",
     "lodash.pick": "4.4.0",
     "media-typer": "0.3.0",

--- a/readme.md
+++ b/readme.md
@@ -107,11 +107,18 @@ When you create your server it takes a config object that allows you to pass in 
     }
 
     // options for hooking into the statsd internal to monument
+    //  The sendXxx all default to false which means that if you want timers for your
+    //  non 200 codes then you will need to turn on the range or ranges you would
+    //  like to see. This is to reduce the chattiness to the statsd server and the
+    //  noise in your stats to a more useful level.
     , statsd: {
         host: 'server-address'
         , port: 'port'
         , prefix: 'string prefix'
         , suffix: 'string suffix'
+        , send3xx: false // this prevents sending timers for 3xx status codes
+        , send4xx: false // this prevents sending timers for 4xx status codes
+        , send5xx: false // this prevents sending timers for 5xx status codes
     }
 }
 ```

--- a/routes/router.js
+++ b/routes/router.js
@@ -74,19 +74,21 @@ module.exports = (routesJson, config) => {
                     , pathname.replace(/[.]/g, '_')
                   ].join('.');
 
-            // Status Code
-            statsdClient.send(`${key}.status_code.${statusCode}`, 1, 'c', 1, [], (err) => {
-              if (err) {
-                logger.error(`[statsd] request count send error: ${err}`);
-              }
-            });
+            if (statsd.shouldSendTimer(config, statusCode)) {
+              // Status Code
+              statsdClient.send(`${key}.status_code.${statusCode}`, 1, 'c', 1, [], (err) => {
+                if (err) {
+                  logger.error(`[statsd] request count send error: ${err}`);
+                }
+              });
 
-            // Response Time
-            statsdClient.timing(`${key}.response_time`, duration, (err) => {
-              if (err) {
-                logger.error(`[statsd] timing send error: ${err}`);
-              }
-            });
+              // Response Time
+              statsdClient.timing(`${key}.response_time`, duration, (err) => {
+                if (err) {
+                  logger.error(`[statsd] timing send error: ${err}`);
+                }
+              });
+            }
 
             cleanupStatsd();
           }

--- a/routes/router.statsd.test.js
+++ b/routes/router.statsd.test.js
@@ -17,6 +17,10 @@ const test = require('ava')
           };
         }
 
+        , shouldSendTimer: function () {
+          return true;
+        }
+
         , create: function () {
           return {
             send: (message) => {

--- a/routes/serverSetup.test.js
+++ b/routes/serverSetup.test.js
@@ -12,7 +12,9 @@ test('should return the list of public folders', (t) => {
 });
 
 test('should throw if an invalid value for routePath is passed', (t) => {
-  t.throws(setup, 'TypeError: path must be a string or Buffer', TypeError);
+    const invalidPathString = '(TypeError \[ERR_INVALID_ARG_TYPE\]: The "path" argument must be one of type string, Buffer, or URL. Received type undefined)' +
+      '| (TypeError: path must be a string or Buffer)';
+  t.throws(setup, new RegExp(invalidPathString), TypeError);
   t.throws(() => {
     setup('somewhere', 'else');
   }, 'Error: ENOENT: no such file or directory, scandir \'somewhere\'');

--- a/routes/serverSetup.test.js
+++ b/routes/serverSetup.test.js
@@ -12,8 +12,9 @@ test('should return the list of public folders', (t) => {
 });
 
 test('should throw if an invalid value for routePath is passed', (t) => {
-    const invalidPathString = '(TypeError \[ERR_INVALID_ARG_TYPE\]: The "path" argument must be one of type string, Buffer, or URL. Received type undefined)' +
-      '| (TypeError: path must be a string or Buffer)';
+  const invalidPathString = '(TypeError \[ERR_INVALID_ARG_TYPE\]: The "path" argument must be one of type string, Buffer, or URL. Received type undefined)' +
+    '| (TypeError: path must be a string or Buffer)';
+
   t.throws(setup, new RegExp(invalidPathString), TypeError);
   t.throws(() => {
     setup('somewhere', 'else');

--- a/utils/config.js
+++ b/utils/config.js
@@ -9,6 +9,9 @@ const path = require('path')
         cacheDns: true
         , port: 8125
         , host: 'localhost'
+        , send500: false
+        , send400: false
+        , send300: false
       }
       , defaults = {
         port: 3000

--- a/utils/statsd.js
+++ b/utils/statsd.js
@@ -1,9 +1,17 @@
 'use strict';
+/* eslint-disable  no-extra-parens */
 
 const StatsD = require('node-statsd');
 
 module.exports = {
   create: (options) => {
     return new StatsD(options);
+  }
+  , shouldSendTimer: (config, statusCode) => {
+    return typeof statusCode === 'string' ? false :
+      statusCode < 300 ||
+      (config.statsd.send4xx && statusCode >= 400 && statusCode < 500) ||
+      (config.statsd.send3xx && statusCode >= 300 && statusCode < 400) ||
+      (config.statsd.send5xx && statusCode >= 500);
   }
 };

--- a/utils/statsd.test.js
+++ b/utils/statsd.test.js
@@ -7,8 +7,72 @@ const test = require('ava')
 test('should return an object', (t) => {
   t.is(typeof statsd, 'object');
   t.is(typeof statsd.create, 'function');
+  t.is(typeof statsd.shouldSendTimer, 'function');
 });
 
 test('statsd.create should return StatsD object', (t) => {
   t.true(statsd.create({}) instanceof StatsD);
 });
+
+test('statsd.shouldSendTimer returns false if statusCode is a string', (t) => {
+  t.false(statsd.shouldSendTimer({ statsd: { send4xx: false, send5xx: false, send3xx: false } }, 'a string'));
+});
+
+test('statsd.shouldSendTimer returns false if statusCode is a 400 and send4xx is false', (t) => {
+  t.false(statsd.shouldSendTimer({ statsd: { send4xx: false, send5xx: false, send3xx: false } }, 400));
+  t.false(statsd.shouldSendTimer({ statsd: { send4xx: false, send5xx: true, send3xx: false } }, 400));
+  t.false(statsd.shouldSendTimer({ statsd: { send4xx: false, send5xx: false, send3xx: true } }, 400));
+  t.false(statsd.shouldSendTimer({ statsd: { send4xx: false, send5xx: true, send3xx: true } }, 400));
+});
+
+test('statsd.shouldSendTimer returns false if statusCode is a 500 and send5xx is false', (t) => {
+  t.false(statsd.shouldSendTimer({ statsd: { send4xx: false, send5xx: false, send3xx: false } }, 500));
+  t.false(statsd.shouldSendTimer({ statsd: { send4xx: true, send5xx: false, send3xx: false } }, 500));
+  t.false(statsd.shouldSendTimer({ statsd: { send4xx: false, send5xx: false, send3xx: true } }, 500));
+  t.false(statsd.shouldSendTimer({ statsd: { send4xx: true, send5xx: false, send3xx: true } }, 500));
+});
+
+test('statsd.shouldSendTimer returns false if statusCode is a 300 and send3xx is false', (t) => {
+  t.false(statsd.shouldSendTimer({ statsd: { send4xx: false, send5xx: false, send3xx: false } }, 300));
+  t.false(statsd.shouldSendTimer({ statsd: { send4xx: true, send5xx: false, send3xx: false } }, 300));
+  t.false(statsd.shouldSendTimer({ statsd: { send4xx: false, send5xx: true, send3xx: false } }, 300));
+  t.false(statsd.shouldSendTimer({ statsd: { send4xx: true, send5xx: true, send3xx: false } }, 300));
+});
+
+test('statsd.shouldSendTimer returns true if statusCode is a 200', (t) => {
+  t.true(statsd.shouldSendTimer({ statsd: { send4xx: false, send5xx: false, send3xx: false } }, 200));
+  t.true(statsd.shouldSendTimer({ statsd: { send4xx: true, send5xx: false, send3xx: false } }, 200));
+  t.true(statsd.shouldSendTimer({ statsd: { send4xx: false, send5xx: false, send3xx: true } }, 200));
+  t.true(statsd.shouldSendTimer({ statsd: { send4xx: true, send5xx: false, send3xx: true } }, 200));
+  t.true(statsd.shouldSendTimer({ statsd: { send4xx: true, send5xx: true, send3xx: true } }, 200));
+});
+
+test('statsd.shouldSendTimer returns true if statusCode is a 100', (t) => {
+  t.true(statsd.shouldSendTimer({ statsd: { send4xx: false, send5xx: false, send3xx: false } }, 100));
+  t.true(statsd.shouldSendTimer({ statsd: { send4xx: true, send5xx: false, send3xx: false } }, 100));
+  t.true(statsd.shouldSendTimer({ statsd: { send4xx: false, send5xx: false, send3xx: true } }, 100));
+  t.true(statsd.shouldSendTimer({ statsd: { send4xx: true, send5xx: false, send3xx: true } }, 100));
+  t.true(statsd.shouldSendTimer({ statsd: { send4xx: true, send5xx: true, send3xx: true } }, 100));
+});
+
+test('statsd.shouldSendTimer returns true if statusCode is a 300 and send3xx is true', (t) => {
+  t.true(statsd.shouldSendTimer({ statsd: { send4xx: false, send5xx: false, send3xx: true } }, 300));
+  t.true(statsd.shouldSendTimer({ statsd: { send4xx: true, send5xx: false, send3xx: true } }, 300));
+  t.true(statsd.shouldSendTimer({ statsd: { send4xx: false, send5xx: true, send3xx: true } }, 300));
+  t.true(statsd.shouldSendTimer({ statsd: { send4xx: true, send5xx: true, send3xx: true } }, 300));
+});
+
+test('statsd.shouldSendTimer returns true if statusCode is a 400 and send4xx is true', (t) => {
+  t.true(statsd.shouldSendTimer({ statsd: { send4xx: true, send5xx: false, send3xx: true } }, 400));
+  t.true(statsd.shouldSendTimer({ statsd: { send4xx: true, send5xx: false, send3xx: false } }, 400));
+  t.true(statsd.shouldSendTimer({ statsd: { send4xx: true, send5xx: true, send3xx: false } }, 400));
+  t.true(statsd.shouldSendTimer({ statsd: { send4xx: true, send5xx: true, send3xx: true } }, 400));
+});
+
+test('statsd.shouldSendTimer returns true if statusCode is a 500 and send5xx is true', (t) => {
+  t.true(statsd.shouldSendTimer({ statsd: { send4xx: true, send5xx: true, send3xx: true } }, 500));
+  t.true(statsd.shouldSendTimer({ statsd: { send4xx: false, send5xx: true, send3xx: false } }, 500));
+  t.true(statsd.shouldSendTimer({ statsd: { send4xx: true, send5xx: true, send3xx: false } }, 500));
+  t.true(statsd.shouldSendTimer({ statsd: { send4xx: false, send5xx: true, send3xx: true } }, 500));
+});
+


### PR DESCRIPTION
Timers are now only sent by default for 100-2xx status codes
this should make the stats more useful and more searchable.