### PR TITLE
Fix failing npm lint script

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "ava-parralel": "ava -s *.test.js utils/**/*.test.js web-sockets/**/*.test.js security/**/*.test.js",
     "router-tests": "ava -s routes/**/*.test.js",
     "start": "node app.js",
-    "lint": "bin/lint.js",
+    "lint": "node bin/lint.js",
     "release": "npm test && echo ' => releasing' && tom",
     "release:minor": "npm test && echo ' => releasing' && tom --type=minor",
     "release:major": "npm test && echo ' => releasing' && tom --type=major",


### PR DESCRIPTION
I cloned this repository to work on #600, but got the error below. The change in this pull request lets me run the test suite via Docker. With this out of the way, I could not reproduce the problem described in #600; that test passed with node 8 as well as node 10.

My developer console:
```sh
> docker build -t monument .
...
> docker run monument
```

Container output:
```sh
2018-10-03T20:34:55.795062900Z 
> monument@5.3.0 test /src
> npm run lint && nyc ava -s *.test.js utils/**/*.test.js web-sockets/**/*.test.js security/**/*.test.js routes/**/*.test.js
2018-10-03T20:34:55.795113500Z 
2018-10-03T20:34:56.009310600Z 
> monument@5.3.0 lint /src
> bin/lint.js
2018-10-03T20:34:56.009360500Z 
/usr/bin/env: node : No such file or directory
npm ERR! file sh
npm ERR! code ELIFECYCLE
npm ERR! errno ENOENT
npm ERR! syscall spawn
npm ERR! monument@5.3.0 lint: `bin/lint.js`
npm ERR! spawn ENOENT
npm ERR! 
npm ERR! Failed at the monument@5.3.0 lint script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
2018-10-03T20:34:56.033124500Z 
npm ERR! A complete log of this run can be found in:
npm ERR!     /root/.npm/_logs/2018-10-03T20_34_56_027Z-debug.log
npm ERR! Test failed.  See above for more details.
```